### PR TITLE
Remove onchange operating_unit_id

### DIFF
--- a/purchase_operating_unit/models/account_invoice.py
+++ b/purchase_operating_unit/models/account_invoice.py
@@ -7,6 +7,11 @@ from odoo import _, api, exceptions, models
 
 class AccountMove(models.Model):
     _inherit = "account.move"
+    
+    purchase_ou_domain = fields.Many2many(
+        comodel_name='purchase.order',
+        compute='_compute_purchase_ou_domain'
+    )
 
     # Load all unsold PO lines
     @api.onchange("purchase_vendor_bill_id", "purchase_id")
@@ -22,16 +27,24 @@ class AccountMove(models.Model):
             self.operating_unit_id = purchase_id.operating_unit_id.id
         return super()._onchange_purchase_auto_complete()
 
-    @api.onchange("operating_unit_id")
-    def _onchange_operating_unit_id(self):
-        """
-        Show only the purchase orders that have the same operating unit
-        """
-        return {
-            "domain": {
-                "purchase_id": [("operating_unit_id", "=", self.operating_unit_id.id)]
-            }
-        }
+    @api.depends('operating_unit_id')
+    def _compute_purchase_ou_domain(self):
+        for rec in self:
+            rec.purchase_ou_domain = self.env['purchase.order'].sudo().search([
+                ('operating_unit_id', '=', rec.operating_unit_id.id)
+            ])
+            
+    # DEPRECATED - Odoo 14 create a warning when onchange return domain.
+    # @api.onchange("operating_unit_id")
+    # def _onchange_operating_unit_id(self):
+    #     """
+    #     Show only the purchase orders that have the same operating unit
+    #     """
+    #     return {
+    #         "domain": {
+    #             "purchase_id": [("operating_unit_id", "=", self.operating_unit_id.id)]
+    #         }
+    #     }
 
 
 class AccountMoveLine(models.Model):


### PR DESCRIPTION
Odoo 14 deprecates return domain from onchange function.