### PR TITLE
use purchase_ou_domain

### DIFF
--- a/purchase_operating_unit/views/account_move_view.xml
+++ b/purchase_operating_unit/views/account_move_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).-->
+<odoo>
+    <record id="view_move_form_inherit" model="ir.ui.view">
+        <field name="name">account.move.form.inherit</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="purchase.view_move_form_inherit_purchase" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='purchase_id']" position="attributes">
+                <attribute name="domain">[('id', 'in', purchase_ou_domain)]</attribute>
+            </xpath>
+            <xpath expr="//field[@name='purchase_id']" position="after">
+                <field name="purchase_ou_domain" invisible="1"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Since onchange function is deprecated, we set the domain for operating_unit_id using purchase_ou_domain in view.